### PR TITLE
feat: :sparkles: remove signer-id config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ or:
 | `app.http.auth.user`             |                        | HTTP endpoint Basic Auth user           |
 | `app.http.auth.password`         |                        | HTTP endpoint Basic Auth password       |
 | `app.http.port`                  | 8080                   | HTTP endpoint port                      |
-| `gics.signer-id`                 | Patienten-ID           | Target consent signerId                 |
 | `kafka.bootstrap-servers`        | localhost:9092         | Kafka brokers                           |
 | `kafka.security-protocol`        | ssl                    | Kafka communication protocol            |
 | `kafka.output-topic`             | gics-notification      | Kafka topic to produce to               |
@@ -116,7 +115,6 @@ gics-to-kafka:
       APP_HTTP_AUTH_USER: test
       APP_HTTP_AUTH_PASSWORD: test
       APP_LOG_LEVEL: info
-      GICS_SIGNER_ID: Patienten-ID
       KAFKA_BOOTSTRAP_SERVERS: kafka:19092
       KAFKA_SECURITY_PROTOCOL: SSL
       KAFKA_SSL_KEY_PASSWORD: private-key-password

--- a/app.yml
+++ b/app.yml
@@ -7,9 +7,6 @@ app:
       password:
     port: 8080
 
-gics:
-  signer-id: "Patienten-ID"
-
 kafka:
   bootstrap-servers: localhost:9092
   security-protocol: ssl

--- a/main_test.go
+++ b/main_test.go
@@ -15,7 +15,6 @@ func TestLoadDefaultConfig(t *testing.T) {
 			LogLevel: "info",
 			Http:     config.Http{Port: "8080"},
 		},
-		Gics: config.Gics{SignerId: "Patienten-ID"},
 		Kafka: config.Kafka{
 			BootstrapServers: "localhost:9092",
 			OutputTopic:      "gics-notification",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,6 @@ import (
 type AppConfig struct {
 	App   App   `mapstructure:"app"`
 	Kafka Kafka `mapstructure:"kafka"`
-	Gics  Gics  `mapstructure:"gics"`
 }
 
 type Http struct {
@@ -34,10 +33,6 @@ type Ssl struct {
 	CertificateLocation string `mapstructure:"certificate-location"`
 	KeyLocation         string `mapstructure:"key-location"`
 	KeyPassword         string `mapstructure:"key-password"`
-}
-
-type Gics struct {
-	SignerId string `mapstructure:"signer-id"`
 }
 
 type Auth struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -13,11 +13,11 @@ func TestLoadConfigWithEnv(t *testing.T) {
 	setProjectDir()
 
 	expected := "test"
-	t.Setenv("GICS_SIGNER_ID", expected)
+	t.Setenv("KAFKA_OUTPUT_TOPIC", expected)
 
 	config, _ := LoadConfig(".")
 
-	assert.Equal(t, expected, config.Gics.SignerId)
+	assert.Equal(t, expected, config.Kafka.OutputTopic)
 }
 
 func TestLoadConfigFileNotFound(t *testing.T) {


### PR DESCRIPTION
Remove unnecessary signer-id configuration. Use first `signerId` property from payload, instead.